### PR TITLE
Port to gupnp-1.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ PKG_PROG_PKG_CONFIG(0.16)
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.28])
 PKG_CHECK_MODULES([GIO], [gio-2.0 >= 2.28])
 PKG_CHECK_MODULES([GMODULE], [gmodule-2.0 >= 2.28])
-PKG_CHECK_MODULES([GUPNP], [gupnp-1.0 >= 0.20.5])
+PKG_CHECK_MODULES([GUPNP], [gupnp-1.2 >= 1.2.0])
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdlib.h string.h syslog.h])

--- a/dleyna-core-1.0.pc.in
+++ b/dleyna-core-1.0.pc.in
@@ -8,5 +8,5 @@ Name: @PACKAGE@
 Description: UPnP & DLNA core library
 Libs: -L${libdir} -ldleyna-core-1.0
 Cflags: -I${includedir}/dleyna-1.0
-Requires: glib-2.0 gio-2.0 gmodule-2.0 gupnp-1.0
+Requires: glib-2.0 gio-2.0 gmodule-2.0 gupnp-1.2
 Version: @VERSION@

--- a/libdleyna/core/main-loop.c
+++ b/libdleyna/core/main-loop.c
@@ -128,10 +128,6 @@ int dleyna_main_loop_start(const char *server,
 {
 	int retval = 1;
 
-#if !GLIB_CHECK_VERSION(2, 35, 0)
-	g_type_init();
-#endif
-
 	dleyna_log_init(server, control_point->get_version());
 
 	if (!prv_context_init(server, control_point))

--- a/libdleyna/core/service-task.c
+++ b/libdleyna/core/service-task.c
@@ -103,6 +103,7 @@ void dleyna_service_task_cancel_cb(dleyna_task_atom_t *atom, gpointer user_data)
 
 	if (task->p_action) {
 		if (task->proxy)
+			// TODO: switch to GCancellable
 			gupnp_service_proxy_cancel_action(task->proxy,
 							  task->p_action);
 		task->p_action = NULL;


### PR DESCRIPTION
The latest version of gupnp breaks backwards compatibility. Fortunately, there are not many calls to gupnp functions in core, so we just needed to bump the dependencies.

There is one deprecated gupnp_service_proxy_cancel_action call but I am not sure how to change it without breaking Dleyna API. Let's leave it for now.